### PR TITLE
Fix - encodeUri used twice (global one removed)

### DIFF
--- a/ampbench_routes.js
+++ b/ampbench_routes.js
@@ -134,13 +134,6 @@ const results_template = fs.readFileSync(__dirname + '/views/results.hbs', 'utf8
 // TODO: WIP20160426 - bulk support routes
 // const multi_url_template = fs.readFileSync(__dirname + '/views/multi_url.hbs', 'utf8');
 
-app.use(function(req, res, next) {
-    if (req.query && req.query.url) {
-        req.query.url = encodeURI(req.query.url);
-    }
-    next();
-});
-
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // ERRORS
 //


### PR DESCRIPTION
The bad URL check was previously performed twice.

Globally through `app.use()`, and locally, through the `assert_url` called within each and every validation endpoint. This was causing the queried URL to be encoded twice, thus resulting in 404 or 500 errors.

As `assert_url` seems to be always used in a "rule-of-thumb" fashion and contains more in-depth checks for the URL's to be validated, I've decided to remove the global one.